### PR TITLE
Add scales object member, because expo Assets expects it

### DIFF
--- a/src/modules/adaptiveImage.js
+++ b/src/modules/adaptiveImage.js
@@ -20,6 +20,9 @@ AdaptiveImage.prototype = {
     get height() {
         return this.data.height
     },
+    get scales() {
+        return this.data.scales
+    },
     toString() {
         return this.data.uri
     }

--- a/src/modules/imageWrapper.js
+++ b/src/modules/imageWrapper.js
@@ -16,6 +16,7 @@ export const createImageWrapper = ( classPath: string ) => ( size: { width: numb
 module.exports = new AdaptiveImage({
     uri: ${uri},${scalings.join('')}
     width: ${size.width},
-    height: ${size.height}
+    height: ${size.height},
+    scales: [1]
 });`
 }


### PR DESCRIPTION
Hi, I am adding react-native-web support to Expo, this package will be used, but it needed this small modification.